### PR TITLE
Feat: 관리자 회원가입 및 로그인 기능 구현

### DIFF
--- a/cookie/src/main/java/com/cookie/domain/user/controller/AuthController.java
+++ b/cookie/src/main/java/com/cookie/domain/user/controller/AuthController.java
@@ -111,4 +111,27 @@ public class AuthController {
         return ResponseEntity.ok(ApiUtil.success("SUCCESS"));
     }
 
+    @PostMapping("/admin")
+    public ResponseEntity<?> loginAdmin(@RequestBody AdminLoginRequest request) {
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.getId(), request.getPassword()));
+
+            String token = jwtUtil.createJwt(
+                    authentication.getName(),
+                    authentication.getAuthorities().iterator().next().getAuthority()
+            );
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", token);
+
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .body(ApiUtil.success("SUCCESS"));
+
+        } catch (AuthenticationException e) {
+            return ResponseEntity.status(401).body(ApiUtil.error(401, "INVALID_CREDENTIALS"));
+        }
+    }
+
 }

--- a/cookie/src/main/java/com/cookie/domain/user/controller/AuthController.java
+++ b/cookie/src/main/java/com/cookie/domain/user/controller/AuthController.java
@@ -1,21 +1,24 @@
 package com.cookie.domain.user.controller;
 
-import com.cookie.domain.user.dto.request.RegisterRequest;
+import com.cookie.domain.user.dto.request.auth.AdminLoginRequest;
+import com.cookie.domain.user.dto.request.auth.AdminRegisterRequest;
+import com.cookie.domain.user.dto.request.auth.RegisterRequest;
 import com.cookie.domain.user.entity.User;
 import com.cookie.domain.user.entity.enums.Role;
 import com.cookie.domain.user.service.UserService;
 import com.cookie.global.jwt.JWTUtil;
 import com.cookie.global.util.ApiUtil;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -25,12 +28,11 @@ public class AuthController {
 
     private final UserService userService;
     private final JWTUtil jwtUtil;
-
-    @Value("${app.client.url}")
-    private String clientUrl;
+    private final AuthenticationManager authenticationManager;
+    private final PasswordEncoder passwordEncoder;
 
     @PostMapping("/register")
-    public ResponseEntity<Object> registerUser(@RequestBody RegisterRequest registerRequest, HttpServletResponse response) throws IOException {
+    public ResponseEntity<Object> registerUser(@RequestBody RegisterRequest registerRequest) {
 
         if (userService.isDuplicateSocial(registerRequest.getSocialProvider(), registerRequest.getSocialId())) {
             return ResponseEntity.badRequest().body(ApiUtil.error(409, "ALREADY_REGISTERED"));
@@ -53,7 +55,7 @@ public class AuthController {
 
         userService.saveUser(newUser);
 
-        String token = jwtUtil.createJwt(newUser.getNickname(), newUser.getRole().name(), 60 * 60 * 60L);
+        String token = jwtUtil.createJwt(newUser.getNickname(), newUser.getRole().name());
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", token);
@@ -86,6 +88,25 @@ public class AuthController {
         if (userService.isDuplicateNickname(nickname)) {
             return ResponseEntity.badRequest().body(ApiUtil.error(400, "DUPLICATED_NICKNAME"));
         }
+
+        return ResponseEntity.ok(ApiUtil.success("SUCCESS"));
+    }
+
+    @PostMapping("/register-admin")
+    public ResponseEntity<?> registerAdmin(@RequestBody AdminRegisterRequest request) {
+        if (userService.isDuplicateNickname(request.getId())) {
+            return ResponseEntity.badRequest().body(ApiUtil.error(400, "DUPLICATED_ID"));
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        User admin = User.builder()
+                .nickname(request.getId())
+                .password(encodedPassword)
+                .role(Role.ADMIN)
+                .build();
+
+        userService.saveUser(admin);
 
         return ResponseEntity.ok(ApiUtil.success("SUCCESS"));
     }

--- a/cookie/src/main/java/com/cookie/domain/user/dto/request/auth/AdminLoginRequest.java
+++ b/cookie/src/main/java/com/cookie/domain/user/dto/request/auth/AdminLoginRequest.java
@@ -1,0 +1,11 @@
+package com.cookie.domain.user.dto.request.auth;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminLoginRequest {
+    private String id;
+    private String password;
+}

--- a/cookie/src/main/java/com/cookie/domain/user/dto/request/auth/AdminRegisterRequest.java
+++ b/cookie/src/main/java/com/cookie/domain/user/dto/request/auth/AdminRegisterRequest.java
@@ -1,0 +1,11 @@
+package com.cookie.domain.user.dto.request.auth;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminRegisterRequest {
+    private String id;
+    private String password;
+}

--- a/cookie/src/main/java/com/cookie/domain/user/dto/request/auth/RegisterRequest.java
+++ b/cookie/src/main/java/com/cookie/domain/user/dto/request/auth/RegisterRequest.java
@@ -1,4 +1,4 @@
-package com.cookie.domain.user.dto.request;
+package com.cookie.domain.user.dto.request.auth;
 
 import com.cookie.domain.user.entity.enums.SocialProvider;
 import lombok.Getter;

--- a/cookie/src/main/java/com/cookie/domain/user/entity/User.java
+++ b/cookie/src/main/java/com/cookie/domain/user/entity/User.java
@@ -29,6 +29,7 @@ public class User extends BaseTimeEntity {
     private String socialId;
     private boolean isPushEnabled;
     private boolean isEmailEnabled;
+    private String password;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserBadge> userBadges = new ArrayList<>();
@@ -43,7 +44,7 @@ public class User extends BaseTimeEntity {
     }
 
     @Builder
-    public User(String nickname, String profileImage, SocialProvider socialProvider, String email, Role role, String socialId, boolean isPushEnabled, boolean isEmailEnabled) {
+    public User(String nickname, String profileImage, SocialProvider socialProvider, String email, Role role, String socialId, boolean isPushEnabled, boolean isEmailEnabled, String password) {
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.socialProvider = socialProvider;
@@ -52,6 +53,7 @@ public class User extends BaseTimeEntity {
         this.socialId = socialId;
         this.isPushEnabled = isPushEnabled;
         this.isEmailEnabled = isEmailEnabled;
+        this.password = password;
     }
 
     public void updateProfile(String profileImage, String nickname) {

--- a/cookie/src/main/java/com/cookie/domain/user/repository/UserRepository.java
+++ b/cookie/src/main/java/com/cookie/domain/user/repository/UserRepository.java
@@ -5,9 +5,12 @@ import com.cookie.domain.user.entity.enums.SocialProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     User findBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
     boolean existsBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
     boolean existsByNickname(String nickname);
+    Optional<User> findByNickname(String nickname);
 }

--- a/cookie/src/main/java/com/cookie/domain/user/service/CustomUserDetailsService.java
+++ b/cookie/src/main/java/com/cookie/domain/user/service/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.cookie.domain.user.service;
+
+import com.cookie.domain.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByNickname(username)
+                .map(user -> User.builder()
+                        .username(user.getNickname())
+                        .password(user.getPassword())
+                        .roles(user.getRole().name())
+                        .build())
+                .orElseThrow(() -> new UsernameNotFoundException("NOT_FOUND_USER"));
+    }
+}

--- a/cookie/src/main/java/com/cookie/global/config/SecurityConfig.java
+++ b/cookie/src/main/java/com/cookie/global/config/SecurityConfig.java
@@ -10,10 +10,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -85,6 +89,7 @@ public class SecurityConfig {
                                 "/api/auth/**",
                                 "/login/oauth2/code/**"
                         ).permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
         );
 
@@ -107,5 +112,15 @@ public class SecurityConfig {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.getWriter().write("{\"statusCode\": \"401\", \"message\": \"UNAUTHORIZED\"}");
         }
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/cookie/src/main/java/com/cookie/global/jwt/JWTUtil.java
+++ b/cookie/src/main/java/com/cookie/global/jwt/JWTUtil.java
@@ -39,7 +39,9 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(String username, String role, Long expiredMs) {
+    public String createJwt(String username, String role) {
+        Long expiredMs = 1000L * 60 * 60 * 24 * 30; // 30일
+
         return Jwts.builder()
                 .claim("username", username)
                 .claim("role", role)

--- a/cookie/src/main/java/com/cookie/global/oauth/CustomSuccessHandler.java
+++ b/cookie/src/main/java/com/cookie/global/oauth/CustomSuccessHandler.java
@@ -47,14 +47,14 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         if (isRegistrationRequired) {
             log.warn("사용자 등록이 필요함");
             String redirectUrl = clientUrl + "/register"
-                    + "?provider=" + customUserDetails.getSocialProvider()
+                    + "?socialProvider=" + customUserDetails.getSocialProvider()
                     + "&email=" + customUserDetails.getEmail()
                     + "&socialId=" + customUserDetails.getSocialId();
 
             response.sendRedirect(redirectUrl);
         } else {
             log.info("기존 사용자 로그인");
-            String token = jwtUtil.createJwt(nickname, role, 60 * 60 * 60L);
+            String token = jwtUtil.createJwt(nickname, role);
             response.addCookie(createCookie("Authorization", token));
 
             response.sendRedirect(clientUrl + "/retrieve-token");


### PR DESCRIPTION
## 🍿 연관된 이슈

> #22 

## 🎬 작업 내용

> 관리자 회원가입
> 관리자 로그인 (일반 로그인)
> 소셜 로그인 & 일반 로그인 통합 : 테스트 완료
> 유저 Role에 따른 API 접근 권한 설정 : /api/admin/** 하위 경로는 관리자만 접근 가능
> 토큰 만료 시간 수정 (임시 30일)
> 기타 리팩토링

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
