### PR TITLE
Feat: 매치업 채팅 기본 작업

### DIFF
--- a/cookie/build.gradle
+++ b/cookie/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // 채팅 메시지 저장용 mongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 }
 
 tasks.named('test') {

--- a/cookie/src/main/java/com/cookie/domain/matchup/controller/ChatController.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/controller/ChatController.java
@@ -1,0 +1,23 @@
+package com.cookie.domain.matchup.controller;
+
+import com.cookie.domain.matchup.dto.response.ChatMessageResponse;
+import com.cookie.domain.matchup.service.ChatService;
+import com.cookie.global.util.ApiUtil.ApiSuccess;
+import com.cookie.global.util.ApiUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/matchup-chat")
+public class ChatController {
+    private final ChatService chatService;
+
+    @GetMapping("/{matchUpId}/messages")
+    public ApiSuccess<?> getMessages(@PathVariable Long matchUpId) {
+        List<ChatMessageResponse> messages = chatService.getMessagesByMatchUpId(matchUpId);
+        return ApiUtil.success(messages);
+    }
+}

--- a/cookie/src/main/java/com/cookie/domain/matchup/controller/ChatMessageController.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/controller/ChatMessageController.java
@@ -1,0 +1,28 @@
+package com.cookie.domain.matchup.controller;
+
+
+import com.cookie.domain.matchup.dto.request.ChatMessageRequest;
+import com.cookie.domain.matchup.dto.response.ChatMessageResponse;
+import com.cookie.domain.matchup.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+/**
+ * 웹소켓 관련 기능
+ */
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+    private final ChatService chatService;
+
+    @MessageMapping("/chat/{matchUpId}/messages") // app/chat/{matchUpId}/messages
+    @SendTo("/topic/chat/{matchUpId}")
+    public ChatMessageResponse sendMessage(@DestinationVariable Long matchUpId, ChatMessageRequest chatMessageRequest) {
+        // TODO: JWT userId 변경
+        Long senderUserId = 1L;
+        return chatService.saveMessage(matchUpId, chatMessageRequest, senderUserId);
+    }
+}

--- a/cookie/src/main/java/com/cookie/domain/matchup/dto/request/ChatMessageRequest.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/dto/request/ChatMessageRequest.java
@@ -1,0 +1,12 @@
+package com.cookie.domain.matchup.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageRequest {
+    private String content;
+}

--- a/cookie/src/main/java/com/cookie/domain/matchup/dto/response/ChatMessageResponse.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/dto/response/ChatMessageResponse.java
@@ -1,0 +1,31 @@
+package com.cookie.domain.matchup.dto.response;
+
+import com.cookie.domain.matchup.entity.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageResponse {
+    private Long matchUpId;
+    private Long senderUserId;
+    private String senderNickname;
+    private String senderProfileImage;
+    private String content;
+    private LocalDateTime sentAt;
+
+    public static ChatMessageResponse fromEntity(ChatMessage chatMessage) {
+        return new ChatMessageResponse(
+                chatMessage.getMatchUpId(),
+                chatMessage.getSenderUserId(),
+                chatMessage.getSenderNickname(),
+                chatMessage.getSenderProfileImage(),
+                chatMessage.getContent(),
+                chatMessage.getSentAt()
+        );
+    }
+}

--- a/cookie/src/main/java/com/cookie/domain/matchup/entity/ChatMessage.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/entity/ChatMessage.java
@@ -1,0 +1,34 @@
+package com.cookie.domain.matchup.entity;
+
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Document(collection = "match_up_messages")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+    @Id
+    private String id;
+    private Long matchUpId;
+    private Long senderUserId;
+    private String senderNickname;
+    private String senderProfileImage;
+    private String content;
+    private LocalDateTime sentAt;
+
+    @Builder
+    public ChatMessage(Long matchUpId, Long senderUserId, String senderNickname, String senderProfileImage, String content, LocalDateTime sentAt) {
+        this.matchUpId = matchUpId;
+        this.senderUserId = senderUserId;
+        this.senderNickname = senderNickname;
+        this.senderProfileImage = senderProfileImage;
+        this.content = content;
+        this.sentAt = sentAt;
+    }
+}

--- a/cookie/src/main/java/com/cookie/domain/matchup/repository/ChatMessageRepository.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/repository/ChatMessageRepository.java
@@ -1,0 +1,12 @@
+package com.cookie.domain.matchup.repository;
+
+import com.cookie.domain.matchup.entity.ChatMessage;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+    List<ChatMessage> findByMatchUpIdOrderBySentAtAsc(Long matchUpId);
+}

--- a/cookie/src/main/java/com/cookie/domain/matchup/service/ChatService.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/service/ChatService.java
@@ -1,0 +1,55 @@
+package com.cookie.domain.matchup.service;
+
+import com.cookie.domain.matchup.dto.request.ChatMessageRequest;
+import com.cookie.domain.matchup.dto.response.ChatMessageResponse;
+import com.cookie.domain.matchup.entity.ChatMessage;
+import com.cookie.domain.matchup.repository.ChatMessageRepository;
+import com.cookie.domain.user.entity.User;
+import com.cookie.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+    @Transactional
+    public ChatMessageResponse saveMessage(Long matchUpId, ChatMessageRequest chatMessageRequest, Long senderUserId) {
+        User user = userRepository.findById(senderUserId)
+                .orElseThrow(() -> new IllegalArgumentException("not found user: " + senderUserId));
+        ChatMessage chatMessage = ChatMessage.builder()
+                .matchUpId(matchUpId)
+                .senderUserId(user.getId())
+                .senderNickname(user.getNickname())
+                .senderProfileImage(user.getProfileImage())
+                .content(chatMessageRequest.getContent())
+                .sentAt(LocalDateTime.now())
+                .build();
+
+        ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
+
+        return ChatMessageResponse.fromEntity(savedChatMessage);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatMessageResponse> getMessagesByMatchUpId(Long matchUpId) {
+        List<ChatMessage> chatMessages = chatMessageRepository.findByMatchUpIdOrderBySentAtAsc(matchUpId);
+        return chatMessages.stream()
+                .map(chatMessage -> new ChatMessageResponse(
+                        chatMessage.getMatchUpId(),
+                        chatMessage.getSenderUserId(),
+                        chatMessage.getSenderNickname(),
+                        chatMessage.getSenderProfileImage(),
+                        chatMessage.getContent(),
+                        chatMessage.getSentAt()
+                ))
+                .toList();
+    }
+}

--- a/cookie/src/main/java/com/cookie/global/config/SecurityConfig.java
+++ b/cookie/src/main/java/com/cookie/global/config/SecurityConfig.java
@@ -88,7 +88,9 @@ public class SecurityConfig {
                                 "/",
                                 "/api/auth/**",
                                 "/login/oauth2/code/**",
-                                "/oauth2/authorization/**"
+                                "/oauth2/authorization/**",
+                                "/api/**", // TODO: will delete
+                                "/ws/**" // TODO: will delete
                         ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/cookie/src/main/java/com/cookie/global/config/WebSocketConfig.java
+++ b/cookie/src/main/java/com/cookie/global/config/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package com.cookie.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic"); // subscription
+        registry.setApplicationDestinationPrefixes("/app"); // publication 메시지 전송
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOrigins("http://localhost:5173/").withSockJS();
+    }
+}


### PR DESCRIPTION
## 🍿 연관된 이슈

> #43

## 🎬 작업 내용

> - STOMP 프로토콜을 통해 실시간 매치업 채팅 기능을 구현했습니다.
> - 채팅 메시지를 MongoDB에 영구적으로 저장하며, 시간순으로 조회할 수 있도록 설정했습니다.
> - 로컬 연동 테스트를 완료했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
