### PR TITLE
Feat: 매치업 진행 관리 구현

### DIFF
--- a/cookie/src/main/java/com/cookie/CookieApplication.java
+++ b/cookie/src/main/java/com/cookie/CookieApplication.java
@@ -2,8 +2,10 @@ package com.cookie;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CookieApplication {
 
     public static void main(String[] args) {

--- a/cookie/src/main/java/com/cookie/domain/matchup/dto/response/MainMatchUpsResponse.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/dto/response/MainMatchUpsResponse.java
@@ -1,0 +1,46 @@
+package com.cookie.domain.matchup.dto.response;
+
+import com.cookie.domain.matchup.entity.MatchUp;
+import com.cookie.domain.matchup.entity.enums.MatchUpType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MainMatchUpsResponse {
+    private List<MainMatchUpResponse> matchUps;
+    private boolean access;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MainMatchUpResponse {
+        private Long matchUpId;
+        private String matchUpTitle;
+        private MatchUpType type;
+        private MainMatchUpMovieResponse movie1;
+        private MainMatchUpMovieResponse movie2;
+
+        public static MainMatchUpResponse fromEntity(MatchUp matchUp) {
+            return new MainMatchUpResponse(
+                    matchUp.getId(),
+                    matchUp.getTitle(),
+                    matchUp.getType(),
+                    new MainMatchUpMovieResponse(matchUp.getMovie1().getMovieTitle(), matchUp.getMovie1().getMoviePoster()),
+                    new MainMatchUpMovieResponse(matchUp.getMovie2().getMovieTitle(), matchUp.getMovie2().getMoviePoster())
+            );
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MainMatchUpMovieResponse {
+        private String movieTitle;
+        private String moviePoster;
+    }
+}

--- a/cookie/src/main/java/com/cookie/domain/matchup/entity/MatchUp.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/entity/MatchUp.java
@@ -49,4 +49,20 @@ public class MatchUp extends BaseTimeEntity {
         this.status = status;
         this.chatroom = chatroom;
     }
+
+    public void changeStatus(MatchUpStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    public void updateWinner() {
+        if (this.movie1.getVoteCount() > this.movie2.getVoteCount()) {
+            this.movie1.changeWinStatus(true);
+        } else if (this.movie1.getVoteCount() < this.movie2.getVoteCount()) {
+            this.movie2.changeWinStatus(true);
+        } else {
+            this.movie1.changeWinStatus(false);
+            this.movie2.changeWinStatus(false);
+        }
+    }
+
 }

--- a/cookie/src/main/java/com/cookie/domain/matchup/entity/MatchUpMovie.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/entity/MatchUpMovie.java
@@ -30,6 +30,9 @@ public class MatchUpMovie {
     public void incrementVoteCount() {
         this.voteCount++;
     }
+    public void changeWinStatus(boolean winStatus) {
+        this.win = winStatus;
+    }
 
     @Builder
     public MatchUpMovie(String movieTitle, String moviePoster, long voteCount, boolean win, CharmPoint charmPoint, EmotionPoint emotionPoint) {
@@ -40,4 +43,5 @@ public class MatchUpMovie {
         this.charmPoint = charmPoint;
         this.emotionPoint = emotionPoint;
     }
+
 }

--- a/cookie/src/main/java/com/cookie/domain/matchup/entity/enums/MatchUpStatus.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/entity/enums/MatchUpStatus.java
@@ -1,5 +1,5 @@
 package com.cookie.domain.matchup.entity.enums;
 
 public enum MatchUpStatus {
-    EXPIRATION, NOW
+    EXPIRATION, NOW, PENDING
 }

--- a/cookie/src/main/java/com/cookie/domain/matchup/repository/MatchUpRepository.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/repository/MatchUpRepository.java
@@ -26,7 +26,9 @@ public interface MatchUpRepository extends JpaRepository<MatchUp, Long> {
             WHERE m.id = :matchUpId""")
     Optional<MatchUp> findMatchUpWithMoviesAndPoints(@Param("matchUpId") Long matchUpId);
 
-    @Query("SELECT m FROM MatchUp m WHERE m.status = :status")
-    Optional<MatchUp> findByStatus(@Param("status") MatchUpStatus status);
+    List<MatchUp> findByStatus(MatchUpStatus status);
+
+    List<MatchUp> findTop2ByStatusOrderByEndAtDesc(MatchUpStatus status);
+
 
 }

--- a/cookie/src/main/java/com/cookie/domain/matchup/repository/MatchUpRepository.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/repository/MatchUpRepository.java
@@ -26,4 +26,7 @@ public interface MatchUpRepository extends JpaRepository<MatchUp, Long> {
             WHERE m.id = :matchUpId""")
     Optional<MatchUp> findMatchUpWithMoviesAndPoints(@Param("matchUpId") Long matchUpId);
 
+    @Query("SELECT m FROM MatchUp m WHERE m.status = :status")
+    Optional<MatchUp> findByStatus(@Param("status") MatchUpStatus status);
+
 }

--- a/cookie/src/main/java/com/cookie/domain/matchup/scheduler/MatchUpScheduler.java
+++ b/cookie/src/main/java/com/cookie/domain/matchup/scheduler/MatchUpScheduler.java
@@ -1,0 +1,26 @@
+package com.cookie.domain.matchup.scheduler;
+
+import com.cookie.domain.matchup.service.MatchUpService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchUpScheduler {
+    private final MatchUpService matchUpService;
+
+    @Scheduled(cron = "0 0 0 ? * MON")
+    public void activateMatchUp() {
+        log.info("Activating match-up: Setting PENDING to NOW");
+        matchUpService.updateMatchUpStatusToNow();
+    }
+
+    @Scheduled(cron = "0 0 0 ? * SUN")
+    public void expireMatchUp() {
+        log.info("Expiring match-up: Setting NOW to EXPIRATION and determining winners");
+        matchUpService.updateMatchUpStatusToExpired();
+    }
+}


### PR DESCRIPTION
## 🍿 연관된 이슈

> #52

## 🎬 작업 내용

> - 매치업의 진행 상태(NOW, PENDING, EXPIRATION)를 관리하고, 만료 시 우승작을 갱신합니다.
> - 프론트엔드에서는 현재 상태에 따라 적절한 화면을 보여줄 수 있도록 데이터를 제공합니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
