### PR TITLE
Fix: 회원가입 시 닉네임 중복체크에서 인증된 사용자 제외

### DIFF
--- a/cookie/src/main/java/com/cookie/domain/user/controller/AuthController.java
+++ b/cookie/src/main/java/com/cookie/domain/user/controller/AuthController.java
@@ -172,9 +172,8 @@ public class AuthController {
     }
 
     @GetMapping("/check-nickname")
-    public ResponseEntity<?> validateNickname(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestParam("nickname") String nickname) {
-        Long userId = customOAuth2User.getId();
-        if (userService.isDuplicateNickname(nickname, userId)) {
+    public ResponseEntity<?> validateNickname(@RequestParam("nickname") String nickname) {
+        if (userService.isDuplicateNicknameRegister(nickname)) {
             return ResponseEntity.ok().body(ApiUtil.success("DUPLICATED_NICKNAME"));
         }
 
@@ -247,4 +246,5 @@ public class AuthController {
         return ResponseEntity.ok().body("AuthenticationPrincipal ID: " + customUserDetails.getId());
     }
 }
+
 


### PR DESCRIPTION
## 🍿 연관된 이슈

> #69

## 🎬 작업 내용

> 회원가입 시 닉네임 중복체크에서 인증된 사용자 제외

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
