### PR TITLE
Feature/#122 push notification settings

### DIFF
--- a/cookie/build.gradle
+++ b/cookie/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 
 
     implementation 'com.google.firebase:firebase-admin:9.4.1'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 
     // Swagger

--- a/cookie/src/main/java/com/cookie/domain/notification/controller/NotificationController.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/controller/NotificationController.java
@@ -1,7 +1,10 @@
 package com.cookie.domain.notification.controller;
 
 import com.cookie.domain.notification.dto.request.FcmTokenRequest;
+import com.cookie.domain.notification.dto.request.NotificationReadRequest;
+import com.cookie.domain.notification.dto.response.NotificationResponse;
 import com.cookie.domain.notification.service.FcmTokenService;
+import com.cookie.domain.notification.service.NotificationService;
 import com.cookie.domain.user.dto.response.auth.CustomOAuth2User;
 import com.cookie.domain.user.service.UserService;
 import com.cookie.global.util.ApiUtil;
@@ -10,18 +13,23 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import java.util.List;
+
+@Slf4j
 @Tag(name = "푸쉬 알림", description = "푸쉬 알림 설정 및 FCM 토큰 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/notification/")
+@RequestMapping("/api/notification")
 public class NotificationController {
 
     private final FcmTokenService fcmTokenService;
     private final UserService userService;
+    private final NotificationService notificationService;
 
     @Operation(summary = "FCM 토큰 저장", description = "사용자의 FCM 토큰을 저장합니다. 푸쉬 알림이 활성화된 사용자만 저장 가능합니다.",
             responses = {
@@ -50,6 +58,8 @@ public class NotificationController {
         return ApiUtil.success("SUCCESS");
     }
 
+
+
     @Operation(summary = "푸쉬 알림 설정 변경", description = "사용자의 푸쉬 알림을 설정합니다. 알림이 활성화되면 FCM 토큰이 저장되고, 비활성화되면 FCM 토큰이 삭제됩니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "푸쉬 알림 설정 변경 성공", content = @Content(mediaType = "application/json")),
@@ -61,6 +71,36 @@ public class NotificationController {
     public ApiSuccess<?> toggleNotification(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody FcmTokenRequest fcmTokenRequest) {
         Long userId = customOAuth2User.getId();
         userService.togglePushNotification(userId, fcmTokenRequest);
+        return ApiUtil.success("SUCCESS");
+    }
+
+
+    @Operation(summary = "사용자의 알림 목록 조회", description = "사용자의 모든 알림을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공", content = @Content(mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(mediaType = "application/json"))
+            }
+    )
+    @GetMapping
+    public ApiSuccess<?> getNotifications(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
+        List<NotificationResponse> notifications = notificationService.getNotifications(userId);
+        return ApiUtil.success(notifications);
+    }
+
+
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 처리합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공", content = @Content(mediaType = "application/json")),
+            }
+    )
+    @PostMapping("/read-status")
+    public ApiSuccess<?> markNotificationAsRead(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody NotificationReadRequest notificationReadRequest) {
+        Long userId = customOAuth2User.getId();
+        String notificationId = notificationReadRequest.getNotificationId();
+
+        notificationService.markNotificationAsRead(userId, notificationId);
+
         return ApiUtil.success("SUCCESS");
     }
 

--- a/cookie/src/main/java/com/cookie/domain/notification/controller/NotificationController.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/controller/NotificationController.java
@@ -2,15 +2,19 @@ package com.cookie.domain.notification.controller;
 
 import com.cookie.domain.notification.dto.request.FcmTokenRequest;
 import com.cookie.domain.notification.service.FcmTokenService;
-import com.cookie.domain.notification.service.NotificationService;
 import com.cookie.domain.user.dto.response.auth.CustomOAuth2User;
 import com.cookie.domain.user.service.UserService;
 import com.cookie.global.util.ApiUtil;
 import com.cookie.global.util.ApiUtil.ApiSuccess;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "푸쉬 알림", description = "푸쉬 알림 설정 및 FCM 토큰 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notification/")
@@ -19,6 +23,13 @@ public class NotificationController {
     private final FcmTokenService fcmTokenService;
     private final UserService userService;
 
+    @Operation(summary = "FCM 토큰 저장", description = "사용자의 FCM 토큰을 저장합니다. 푸쉬 알림이 활성화된 사용자만 저장 가능합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "FCM 토큰 저장 성공", content = @Content(mediaType = "application/json")),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(mediaType = "application/json"))
+            }
+    )
     @PostMapping("/fcm-token")
     public ApiSuccess<?> saveFcmToken(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody FcmTokenRequest fcmTokenRequest) {
         Long userId = customOAuth2User.getId();
@@ -26,6 +37,12 @@ public class NotificationController {
         return ApiUtil.success("SUCCESS");
     }
 
+    @Operation(summary = "FCM 토큰 삭제", description = "사용자의 FCM 토큰을 삭제합니다. 로그아웃 및 푸쉬 알림을 비활성화할 때 호출됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "FCM 토큰 삭제 성공", content = @Content(mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(mediaType = "application/json"))
+            }
+    )
     @DeleteMapping("/fcm-token")
     public ApiSuccess<?> deleteFcmToken(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         Long userId = customOAuth2User.getId();
@@ -33,6 +50,13 @@ public class NotificationController {
         return ApiUtil.success("SUCCESS");
     }
 
+    @Operation(summary = "푸쉬 알림 설정 변경", description = "사용자의 푸쉬 알림을 설정합니다. 알림이 활성화되면 FCM 토큰이 저장되고, 비활성화되면 FCM 토큰이 삭제됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "푸쉬 알림 설정 변경 성공", content = @Content(mediaType = "application/json")),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(mediaType = "application/json"))
+            }
+    )
     @PostMapping("/settings")
     public ApiSuccess<?> toggleNotification(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody FcmTokenRequest fcmTokenRequest) {
         Long userId = customOAuth2User.getId();

--- a/cookie/src/main/java/com/cookie/domain/notification/controller/NotificationController.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/controller/NotificationController.java
@@ -4,6 +4,7 @@ import com.cookie.domain.notification.dto.request.FcmTokenRequest;
 import com.cookie.domain.notification.service.FcmTokenService;
 import com.cookie.domain.notification.service.NotificationService;
 import com.cookie.domain.user.dto.response.auth.CustomOAuth2User;
+import com.cookie.domain.user.service.UserService;
 import com.cookie.global.util.ApiUtil;
 import com.cookie.global.util.ApiUtil.ApiSuccess;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
 
     private final FcmTokenService fcmTokenService;
+    private final UserService userService;
 
     @PostMapping("/fcm-token")
     public ApiSuccess<?> saveFcmToken(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody FcmTokenRequest fcmTokenRequest) {
@@ -28,6 +30,13 @@ public class NotificationController {
     public ApiSuccess<?> deleteFcmToken(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         Long userId = customOAuth2User.getId();
         fcmTokenService.deleteFcmToken(userId); // 토큰 삭제
+        return ApiUtil.success("SUCCESS");
+    }
+
+    @PostMapping("/settings")
+    public ApiSuccess<?> toggleNotification(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody FcmTokenRequest fcmTokenRequest) {
+        Long userId = customOAuth2User.getId();
+        userService.togglePushNotification(userId, fcmTokenRequest);
         return ApiUtil.success("SUCCESS");
     }
 

--- a/cookie/src/main/java/com/cookie/domain/notification/dto/request/NotificationReadRequest.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/dto/request/NotificationReadRequest.java
@@ -1,0 +1,13 @@
+package com.cookie.domain.notification.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationReadRequest {
+    private String notificationId;
+}
+

--- a/cookie/src/main/java/com/cookie/domain/notification/dto/request/NotificationRequest.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/dto/request/NotificationRequest.java
@@ -1,0 +1,17 @@
+package com.cookie.domain.notification.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationRequest {
+    private String body;
+    private String senderProfileImage;
+    private LocalDateTime timestamp;
+}

--- a/cookie/src/main/java/com/cookie/domain/notification/dto/request/NotificationRequest.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/dto/request/NotificationRequest.java
@@ -1,17 +1,32 @@
 package com.cookie.domain.notification.dto.request;
 
 
-import lombok.AllArgsConstructor;
+import com.cookie.domain.notification.entity.enums.Status;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class NotificationRequest {
+    private String notificationId;
     private String body;
     private String senderProfileImage;
     private LocalDateTime timestamp;
+    private Long reviewId;
+    @Setter
+    private Status status;
+
+    @Builder
+    public NotificationRequest(String notificationId, String body, String senderProfileImage, LocalDateTime timestamp, Long reviewId, Status status) {
+        this.notificationId = notificationId;
+        this.body = body;
+        this.senderProfileImage = senderProfileImage;
+        this.timestamp = timestamp;
+        this.reviewId = reviewId;
+        this.status = status;
+    }
 }

--- a/cookie/src/main/java/com/cookie/domain/notification/dto/response/NotificationResponse.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,21 @@
+package com.cookie.domain.notification.dto.response;
+
+import com.cookie.domain.notification.entity.enums.Status;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponse {
+    private String notificationId;
+    private String body;
+    private String senderProfileImage;
+    private LocalDateTime timestamp;
+    private Long reviewId;
+    private Status status;
+
+}

--- a/cookie/src/main/java/com/cookie/domain/notification/entity/enums/Status.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/entity/enums/Status.java
@@ -1,0 +1,5 @@
+package com.cookie.domain.notification.entity.enums;
+
+public enum Status {
+    READ, UNREAD
+}

--- a/cookie/src/main/java/com/cookie/domain/notification/repository/FcmTokenRepository.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/repository/FcmTokenRepository.java
@@ -13,4 +13,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
     Optional<FcmToken> findByUserId(Long userId);
     boolean existsByTokenAndUser(String token, User user);
+
+    Optional<FcmToken> findByToken(String token);
 }

--- a/cookie/src/main/java/com/cookie/domain/notification/scheduler/NotificationScheduler.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/scheduler/NotificationScheduler.java
@@ -1,0 +1,66 @@
+package com.cookie.domain.notification.scheduler;
+
+import com.cookie.domain.notification.dto.request.NotificationRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationScheduler {
+    private final RedisTemplate<String, Object> template;
+    private final ObjectMapper objectMapper;
+
+    private static final String NOTIFICATION_KEY = "notifications:user:";
+
+    @Async
+    @Scheduled(cron = "0 0 4 * * *")
+    public void syncNotificationsRedisToRds() {
+        Set<String> keys = template.keys(NOTIFICATION_KEY + "*");
+
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        for (String key : keys) {
+            List<Object> notifications = template.opsForList().range(key, 0, -1);
+
+            if (notifications == null || notifications.isEmpty()) {
+                continue;
+            }
+
+            for (Object notification : notifications) {
+                try {
+                    String jsonString = notification.toString();
+                    NotificationRequest notificationRequest = objectMapper.readValue(jsonString, NotificationRequest.class);
+
+                    if (notificationRequest.getTimestamp() == null) {
+                        log.warn("Notification with null timestamp: {}", notificationRequest);
+                        continue;
+                    }
+
+                    LocalDateTime notificationTimestamp = notificationRequest.getTimestamp();
+
+                    if (notificationTimestamp.isBefore(now.minusDays(30))) {
+                        template.opsForList().remove(key, 1, jsonString);
+                        log.info("만료된 알림을 삭제했습니다.: {}", key);
+                    }
+
+                } catch (Exception e) {
+                    log.error("Error parsing notification JSON: {}", notification, e);
+                }
+            }
+        }
+    }
+}

--- a/cookie/src/main/java/com/cookie/domain/notification/service/FcmTokenService.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/service/FcmTokenService.java
@@ -18,7 +18,7 @@ public class FcmTokenService {
     private final FcmTokenRepository fcmTokenRepository;
 
     public void saveFcmToken(Long userId, String token) {
-        log.info("saveToken userId: {} and token: {}", userId, token);
+        log.info("Start saveToken userId: {} and token: {}", userId, token);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("not found userId: " + userId));

--- a/cookie/src/main/java/com/cookie/domain/notification/service/FcmTokenService.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/service/FcmTokenService.java
@@ -7,6 +7,7 @@ import com.cookie.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -17,6 +18,7 @@ public class FcmTokenService {
     private final UserRepository userRepository;
     private final FcmTokenRepository fcmTokenRepository;
 
+    @Transactional
     public void saveFcmToken(Long userId, String token) {
         log.info("Start saveToken userId: {} and token: {}", userId, token);
 
@@ -47,6 +49,7 @@ public class FcmTokenService {
         }
     }
 
+    @Transactional
     public void deleteFcmToken(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("not found userId: " + userId));

--- a/cookie/src/main/java/com/cookie/domain/notification/service/NotificationService.java
+++ b/cookie/src/main/java/com/cookie/domain/notification/service/NotificationService.java
@@ -1,18 +1,28 @@
 package com.cookie.domain.notification.service;
 
 
-import com.cookie.domain.category.repository.CategoryRepository;
-import com.cookie.domain.category.entity.Category;
+import com.cookie.domain.notification.dto.request.NotificationRequest;
+import com.cookie.domain.notification.dto.response.NotificationResponse;
+import com.cookie.domain.notification.entity.FcmToken;
+import com.cookie.domain.notification.entity.enums.Status;
+import com.cookie.domain.notification.repository.FcmTokenRepository;
+import com.cookie.domain.user.entity.User;
 import com.cookie.domain.user.repository.UserRepository;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -20,87 +30,130 @@ import java.util.List;
 public class NotificationService {
 
     private final UserRepository userRepository;
-    private final CategoryRepository categoryRepository;
+    private final FcmTokenRepository fcmTokenRepository;
     private final FirebaseMessaging firebaseMessaging;
+    private final RedisTemplate<String, Object> template;
+    private final ObjectMapper objectMapper;
+    private static final String NOTIFICATION_KEY = "notifications:user:";
 
-    public void subscribeToTopic(String token, Long categoryId, Long userId) {
+    /**
+     * 푸쉬알림 전송
+     */
+    @Async
+    public void sendPushNotificationToUsers(Long senderId, List<String> tokens, String title, String body, Long reviewId) {
+        User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> new IllegalArgumentException("not found userId"));
+        String senderProfileImage = sender.getProfileImage();
 
-        userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("not found userId: " + userId));
-
-        Category category = categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new IllegalArgumentException("not found categoryId: " + categoryId));
-
-        String topic = category.getSubCategoryEn();
-
-        try {
-            FirebaseMessaging.getInstance().subscribeToTopic(List.of(token), topic);
-            log.info("Subscribed to topic: {}", topic);
-        } catch (FirebaseMessagingException e) {
-            log.error("Failed subscribe to topic: {}", e.getMessage());
-
-        }
-
-    }
-
-    public void unsubscribeFromTopic(String token, Long categoryId, Long userId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("not found userId: " + userId));
-
-        Category category = categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new IllegalArgumentException("not found categoryId: " + categoryId));
-
-        String topic = category.getSubCategoryEn();
-
-        try {
-            FirebaseMessaging.getInstance().unsubscribeFromTopic(List.of(token), topic);
-            log.info("Unsubscribed from topic: {}", topic);
-        } catch (FirebaseMessagingException e) {
-            log.error("Failed to unsubscribe from topic: {}", e.getMessage());
-        }
-    }
-
-
-    public void sendPushNotificationToTopic(String topic, String title, String body) {
-        Message message = Message.builder()
-                .setNotification(Notification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .build())
-                .setTopic(topic)
-                .build();
-
-        try {
-            String response = firebaseMessaging.send(message);
-            log.info("Send push notification: {}", response);
-        } catch (FirebaseMessagingException e) {
-            log.error("Error sending push notification: {}", e.getMessage());
-        }
-    }
-
-
-    public void sendPushNotificationToUsers(List<String> tokens, String title, String body) {
         for (String token : tokens) {
-            // 작성자의 토큰은 제외
-//            if (excludedTokens.contains(token)) {
-//                continue;
-//            }
+
+            FcmToken fcmToken = fcmTokenRepository.findByToken(token)
+                    .orElseThrow(() -> new IllegalArgumentException("not found token"));
+            Long userId = fcmToken.getUser().getId(); // 받는 사람 id
+
 
             Message message = Message.builder()
-                    .setToken(token)
-                    .setNotification(Notification.builder()
-                            .setTitle(title)
-                            .setBody(body)
+                    .setWebpushConfig(WebpushConfig.builder()
+                            .putHeader("Urgency", "high")
                             .build())
+                    .putData("title", title)
+                    .putData("body", body)
+                    .setToken(token)
                     .build();
 
             try {
-                String response = firebaseMessaging.send(message);
-                log.info("Push notification sent successfully to token: {}", token);
+                firebaseMessaging.send(message); // 푸쉬 알림 전송
+                log.info("푸쉬 알림 전송 성공: token {}", token);
+                saveUserNotificationToRedis(userId, body, senderProfileImage, reviewId); // 알림 저장
             } catch (FirebaseMessagingException e) {
-                log.error("Error sending push notification to token {}: {}", token, e.getMessage());
+                log.error("푸쉬 알림 전송 실패: token {}, error: {}", token, e.getMessage());
             }
         }
     }
 
+
+    /*
+     * 사용자 별 알림 리스트 조회
+     */
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getNotifications(Long userId) {
+        String key = NOTIFICATION_KEY + userId;
+        List<Object> notifications = template.opsForList().range(key, 0, -1);
+
+        if (notifications == null) {
+            log.warn("알림이 존재하지 않습니다. userId: {}", userId);
+            return new ArrayList<>();
+        }
+
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        List<NotificationResponse> result = new ArrayList<>();
+
+        for (Object notification : notifications) {
+            try {
+                NotificationResponse notificationResponse = objectMapper.readValue(notification.toString(), NotificationResponse.class);
+                result.add(notificationResponse);
+            } catch (Exception e) {
+                log.error("Error parsing notification JSON: {}", notification, e);
+            }
+        }
+
+        return result;
+    }
+
+
+    /*
+     * redis 알림 저장
+     */
+    @Async
+    public void saveUserNotificationToRedis(Long userId, String body, String senderProfileImage, Long reviewId) {
+        String key = NOTIFICATION_KEY + userId;
+
+        NotificationRequest notificationRequest = NotificationRequest.builder()
+                .notificationId(UUID.randomUUID().toString())
+                .body(body)
+                .senderProfileImage(senderProfileImage)
+                .timestamp(LocalDateTime.now())
+                .reviewId(reviewId)
+                .status(Status.UNREAD)
+                .build();
+
+        try {
+            template.opsForList().leftPush(key, objectMapper.writeValueAsString(notificationRequest));
+            log.info("알림 저장 성공 userId: {}", userId);
+        } catch (Exception e) {
+            log.error("Error saving notification to Redis: {}", e.getMessage());
+        }
+    }
+
+
+    /*
+     * 읽음 처리 갱신
+     */
+    public void markNotificationAsRead(Long userId, String notificationId) {
+        String key = NOTIFICATION_KEY + userId;
+
+        List<Object> notifications = template.opsForList().range(key, 0, -1);
+        if (notifications == null || notifications.isEmpty()) {
+            log.warn("알림이 존재하지 않습니다. userId: {}", userId);
+            return;
+        }
+
+        for (int i = 0; i < notifications.size(); i++) {
+            try {
+                NotificationRequest notificationRequest = objectMapper.readValue(notifications.get(i).toString(), NotificationRequest.class);
+
+                if (notificationRequest.getNotificationId().equals(notificationId)) {
+                    notificationRequest.setStatus(Status.READ);
+                    template.opsForList().set(key, i, objectMapper.writeValueAsString(notificationRequest));
+                    log.info("알림 읽음 처리 완료: userId {}, notificationId {}", userId, notificationId);
+                    return;
+                }
+            } catch (Exception e) {
+                log.error("Error parsing or updating notification: {}", notifications.get(i), e);
+            }
+        }
+
+        log.warn("일치하는 알림을 찾을 수 없습니다 userId: {} and notificationId: {}", userId, notificationId);
+    }
 }
+

--- a/cookie/src/main/java/com/cookie/domain/review/service/ReviewService.java
+++ b/cookie/src/main/java/com/cookie/domain/review/service/ReviewService.java
@@ -115,19 +115,13 @@ public class ReviewService {
 
         for (String genre : enGenres) {
             stepTime = System.currentTimeMillis();
-            List<String> userTokens = userRepository.findTokensByGenreAndExcludeUser(genre, userId);
+            List<String> userTokens = userRepository.findTokensByGenreAndExcludeUser(genre, userId); // 알림을 받는 사람들의 토큰 목록
             log.info("Fetched user tokens for genre '{}', Time Taken: {} ms", genre, System.currentTimeMillis() - stepTime);
-
-//            stepTime = System.currentTimeMillis();
-//            List<String> excludedTokens = user.getFcmTokens().stream()
-//                    .map(FcmToken::getToken)
-//                    .toList();
-//            log.info("Extracted excluded tokens, Time Taken: {} ms", System.currentTimeMillis() - stepTime);
 
             stepTime = System.currentTimeMillis();
             String title ="Cookie 🍪";
             String body = String.format("%s님이 %s 영화에 리뷰를 등록했어요!.", user.getNickname(), movie.getTitle());
-            notificationService.sendPushNotificationToUsers(userTokens, title, body);
+            notificationService.sendPushNotificationToUsers(userId, userTokens, title, body, savedReview.getId());
             log.info("Sent push notification for genre '{}', Time Taken: {} ms", genre, System.currentTimeMillis() - stepTime);
         }
 
@@ -155,47 +149,6 @@ public class ReviewService {
 //            }
 //        }
 //    }
-
-//    @Async
-//    public void sendPushNotification(Long userId, Movie movie, Review review, CopyOnWriteArrayList<SseEmitter> pushNotificationEmitters) {
-//        log.info("movie title: {}", movie.getTitle());
-//
-//        List<String> genres = movieRepository.findGenresByMovieId(movie.getId());
-//        log.info("영화 [{}]의 장르 정보: {}", movie.getTitle(), genres);
-//
-//        List<User> genreFans = userRepository.findUsersByFavoriteGenresInAndExcludeUserId(genres, userId);
-//        log.info("장르를 좋아하는 유저 {}명", genreFans.size());
-//
-//        PushNotification pushNotification = new PushNotification(review.getMovie().getId(), review.getMovie().getTitle(), review.getUser().getNickname());
-//
-//        sendNotificationToUser(genreFans, pushNotification, pushNotificationEmitters);
-//    }
-//    private void sendNotificationToUser(List<User> genreFans, PushNotification pushNotification, CopyOnWriteArrayList<SseEmitter> pushNotificationEmitters) {
-//        for (User fan : genreFans) {
-//            if (fan.isPushEnabled()) { // pushEnabled 가 true 인 경우에만 알림 전송
-//                try {
-//                    String notificationMessage = String.format("[%s]님 새로운 리뷰가 등록되었습니다! [%s]", fan.getNickname(), pushNotification.getMovieTitle());
-//                    log.info("푸시 알림 전송 성공: {}", notificationMessage);
-//
-//                    for (SseEmitter emitter : pushNotificationEmitters) {
-//                        try {
-//                            emitter.send(SseEmitter.event()
-//                                    .name("push-notification")
-//                                    .data(pushNotification));
-//                        } catch (Exception e) {
-//                            log.error("Failed to send event to emitter for user [{}]: {}", fan.getId(), e.getMessage());
-//                            pushNotificationEmitters.remove(emitter);
-//                        }
-//                    }
-//                } catch (Exception e) {
-//                    log.error("Failed to send push notification to user: {}", fan.getId(), e);
-//                }
-//            } else {
-//                log.info("유저 [{}]는 푸시 알림을 비활성화 했습니다.", fan.getId());
-//            }
-//        }
-//    }
-
 
     @Transactional
     public void updateReview(Long reviewId, UpdateReviewRequest updateReviewRequest) {

--- a/cookie/src/main/java/com/cookie/domain/review/service/ReviewService.java
+++ b/cookie/src/main/java/com/cookie/domain/review/service/ReviewService.java
@@ -125,8 +125,8 @@ public class ReviewService {
 //            log.info("Extracted excluded tokens, Time Taken: {} ms", System.currentTimeMillis() - stepTime);
 
             stepTime = System.currentTimeMillis();
-            String title = String.format("%s님 새로운 리뷰가 등록되었습니다!", user.getId());
-            String body = String.format("%s님이 %s 영화에 리뷰를 남겼습니다.", user.getNickname(), movie.getTitle());
+            String title ="Cookie 🍪";
+            String body = String.format("%s님이 %s 영화에 리뷰를 등록했어요!.", user.getNickname(), movie.getTitle());
             notificationService.sendPushNotificationToUsers(userTokens, title, body);
             log.info("Sent push notification for genre '{}', Time Taken: {} ms", genre, System.currentTimeMillis() - stepTime);
         }

--- a/cookie/src/main/java/com/cookie/domain/user/entity/User.java
+++ b/cookie/src/main/java/com/cookie/domain/user/entity/User.java
@@ -104,5 +104,10 @@ public class User extends BaseTimeEntity {
         this.category = genreId;
     }
 
+    public void updatePushNotification(boolean isPushEnabled) {
+        this.isPushEnabled = isPushEnabled;
+    }
+
 }
+
 

--- a/cookie/src/main/java/com/cookie/global/config/RedisConfig.java
+++ b/cookie/src/main/java/com/cookie/global/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.cookie.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}


### PR DESCRIPTION
## 🍿 연관된 이슈

> #122

## 🎬 작업 내용

> - 백그라운드에서 알림이 두 번 전송되는 버그를 해결하여 FCM 토큰 기반 전송 방식으로 푸쉬 알림 시스템을 구현을 완료했습니다.
> - 푸쉬알림 전송 시 redis에 알림 관련 정보를 저장합니다 (고유ID, 알림내용, 리뷰작성자 프로필 이미지, 전송 시간, 읽음상태)
> - 알림은 30일 이후 만료되고 스케줄러를 통해 매일 새벽 4시 만료된 알림 목록을 제거합니다.
> - 알림 읽음 상태 갱신을 위한 API를 구현했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 꼼꼼히 봐주세요!!
