### PR TITLE
Feature/#129 movie images cdn

### DIFF
--- a/cookie/src/main/java/com/cookie/admin/controller/AdminMovieController.java
+++ b/cookie/src/main/java/com/cookie/admin/controller/AdminMovieController.java
@@ -5,8 +5,10 @@ import com.cookie.admin.service.movie.AdminMovieCreateService;
 import com.cookie.admin.service.movie.AdminMovieModifyService;
 import com.cookie.admin.service.movie.AdminMovieReadService;
 import com.cookie.admin.service.movie.AdminMovieSearchService;
+import com.cookie.global.service.AWSS3CndService;
 import com.cookie.global.util.ApiUtil;
 import com.cookie.global.util.ApiUtil.ApiSuccess;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -30,6 +32,7 @@ public class AdminMovieController {
     private final AdminMovieReadService adminMovieReadService;
     private final AdminMovieModifyService adminMovieModifyService;
     private final AdminMovieSearchService adminMovieSearchService;
+    private final AWSS3CndService awss3CndService;
 
     @Operation(summary = "영화 초기 세팅 값 - 4600편", responses = {
             @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json",
@@ -136,5 +139,12 @@ public class AdminMovieController {
     public ApiSuccess<?> getMovies(@PathVariable("pageNumber") Integer pageNumber) {
         AdminMoviesResponse data = adminMovieSearchService.getMovies(pageNumber);
         return ApiUtil.success(data);
+    }
+
+    @Hidden
+    @PostMapping("/movies/updateUrl")
+    public ApiSuccess<?> updateImagesByOnce() {
+        awss3CndService.updateImagesByOnce();
+        return ApiUtil.success("SUCCESS");
     }
 }

--- a/cookie/src/main/java/com/cookie/domain/actor/repository/ActorRepository.java
+++ b/cookie/src/main/java/com/cookie/domain/actor/repository/ActorRepository.java
@@ -1,11 +1,9 @@
 package com.cookie.domain.actor.repository;
 
 import com.cookie.domain.actor.dto.response.ActorResponse;
-import com.cookie.domain.actor.dto.response.ActorResponse;
 import com.cookie.domain.actor.entity.Actor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,6 +33,21 @@ public interface ActorRepository extends JpaRepository<Actor, Long> {
             + "JOIN MovieActor ma ON ma.actor.id = a.id "
             + "WHERE ma.movie.id = :movieId")
     List<ActorResponse> findActorsByMovieId(@Param("movieId") Long movieId);
+
+
+    @Query("""
+        SELECT a.profileImage
+        FROM Actor a
+    """)
+    List<String> findAllTMDBImages();
+
+    @Modifying
+    @Query("""
+        UPDATE Actor a
+        SET a.profileImage = :cloudFrontUrl
+        WHERE a.profileImage = :TmdbBUrl
+    """)
+    void updateImageByFileName(@Param("TmdbBUrl") String TmdbBUrl, @Param("cloudFrontUrl") String cloudFrontUrl);
 }
 
 

--- a/cookie/src/main/java/com/cookie/domain/director/repository/DirectorRepository.java
+++ b/cookie/src/main/java/com/cookie/domain/director/repository/DirectorRepository.java
@@ -4,6 +4,7 @@ import com.cookie.domain.director.entity.Director;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -26,4 +27,18 @@ public interface DirectorRepository extends JpaRepository<Director, Long> {
             WHERE d.id =:directorId
            """)
     List<Director> findAllMoviesByDirectorId(@Param("directorId")Long directorId);
+
+    @Query("""
+    SELECT d.profileImage
+    FROM Director d
+    """)
+    List<String> findAllTMDBImages();
+
+    @Modifying
+    @Query("""
+        UPDATE Director d
+        SET d.profileImage = :cloudFrontUrl
+        WHERE d.profileImage = :TmdbBUrl
+    """)
+    void updateImageByFileName(@Param("TmdbBUrl") String TmdbBUrl, @Param("cloudFrontUrl") String cloudFrontUrl);
 }

--- a/cookie/src/main/java/com/cookie/domain/movie/repository/MovieImageRepository.java
+++ b/cookie/src/main/java/com/cookie/domain/movie/repository/MovieImageRepository.java
@@ -20,4 +20,17 @@ public interface MovieImageRepository extends JpaRepository<MovieImage, Long> {
     @Query("SELECT mi.url FROM MovieImage mi WHERE mi.movie.id = :movieId")
     List<String> findImageUrlsByMovieId(@Param("movieId") Long movieId);
 
+    @Query("""
+    SELECT mi.url
+    FROM MovieImage mi
+    """)
+    List<String> findAllTMDBImages();
+
+    @Modifying
+    @Query("""
+        UPDATE MovieImage mi
+        SET mi.url = :cloudFrontUrl
+        WHERE mi.url = :TmdbBUrl
+    """)
+    void updateImageByFileName(@Param("TmdbBUrl") String TmdbBUrl, @Param("cloudFrontUrl") String cloudFrontUrl);
 }

--- a/cookie/src/main/java/com/cookie/domain/movie/repository/MovieRepository.java
+++ b/cookie/src/main/java/com/cookie/domain/movie/repository/MovieRepository.java
@@ -90,5 +90,18 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
     """)
     List<Movie> findAllByTMDBMovieIds(@Param("tmdbIds") Set<Long> tmdbIds);
 
+    @Query("""
+    SELECT m.poster
+    FROM Movie m
+    """)
+    List<String> findAllTMDBImages();
+
+    @Modifying
+    @Query("""
+    UPDATE Movie m
+    SET m.poster = :cloudFrontUrl
+    WHERE m.poster = :TmdbBUrl
+    """)
+    void updateImageByFileName(@Param("TmdbBUrl") String TmdbBUrl, @Param("cloudFrontUrl") String cloudFrontUrl);
 }
 

--- a/cookie/src/main/java/com/cookie/global/service/AWSS3CndService.java
+++ b/cookie/src/main/java/com/cookie/global/service/AWSS3CndService.java
@@ -1,0 +1,88 @@
+package com.cookie.global.service;
+
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.cookie.domain.actor.repository.ActorRepository;
+import com.cookie.domain.director.repository.DirectorRepository;
+import com.cookie.domain.movie.repository.MovieImageRepository;
+import com.cookie.domain.movie.repository.MovieRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AWSS3CndService {
+
+    private final AmazonS3 amazonS3;
+
+    private final MovieRepository movieRepository;
+    private final ActorRepository actorRepository;
+    private final DirectorRepository directorRepository;
+    private final MovieImageRepository movieImageRepository;
+
+    @Value("${cloud.front.baseUrl}")
+    private String cloudFrontBaseUrl;
+
+    @Transactional
+    public void updateImagesByOnce() {
+        processAndUploadImages(movieRepository.findAllTMDBImages(), movieRepository::updateImageByFileName);
+        processAndUploadImages(actorRepository.findAllTMDBImages(), actorRepository::updateImageByFileName);
+        processAndUploadImages(directorRepository.findAllTMDBImages(), directorRepository::updateImageByFileName);
+        processAndUploadImages(movieImageRepository.findAllTMDBImages(), movieImageRepository::updateImageByFileName);
+    }
+
+    public void processAndUploadImages(List<String> tmdbImageUrls, BiConsumer<String, String> updateRepository) {
+        tmdbImageUrls.forEach(url -> {
+            try {
+                if (url == null || url.isEmpty() || url.endsWith("/null") || url.startsWith("https://d320gmmmso0682")) {
+                    return;
+                }
+
+                byte[] imageBytes = downloadImageFromTMDB(url);
+
+                String fileName = extractFileNameFromUrl(url);
+
+                uploadToS3(fileName, imageBytes);
+
+                String cloudFrontUrl = cloudFrontBaseUrl + fileName;
+
+                updateRepository.accept(url, cloudFrontUrl);
+
+            } catch (Exception e) {
+                log.error("Failed to process URL: {}", url, e);
+            }
+        });
+    }
+
+    private byte[] downloadImageFromTMDB(String imageUrl) throws IOException {
+        URL url = new URL(imageUrl);
+        try (InputStream inputStream = url.openStream()) {
+            return inputStream.readAllBytes();
+        }
+    }
+
+    private String extractFileNameFromUrl(String imageUrl) throws MalformedURLException {
+        return Paths.get(new URL(imageUrl).getPath()).getFileName().toString();
+    }
+
+    private void uploadToS3(String s3Key, byte[] imageBytes) {
+        String bucketName = "movie-images-bucket";
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(imageBytes.length);
+        amazonS3.putObject(bucketName, s3Key, new ByteArrayInputStream(imageBytes), metadata);
+    }
+}


### PR DESCRIPTION
## 🍿 연관된 이슈

> ex) #129 

## 🎬 작업 내용

- S3 Bucket 생성 ( 영화 관련 이미지 저장소 )
- CDN 구축 후 연결 
- 기존 영화 관련 모든 이미지 cdn 업데이트 처리 기능 구현

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
